### PR TITLE
Port Github Actions CI Script

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,20 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  test-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Ruby 2.6
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+
+      - name: Install Bundle Dependencies 
+        run: bundle install
+
+      - name: Build
+        run: bundle exec jekyll build


### PR DESCRIPTION
Ports the GitHub Action script from the old repository and the one the gridcoin.us site uses

Looks like it didn't get ported over when this repository was created