### PR TITLE
fix: remove obsolete view details button on join

### DIFF
--- a/join.htm
+++ b/join.htm
@@ -8,7 +8,6 @@ title: "Join the Network - Gridcoin"
             <div class="flair-square-dots"></div>
             <h1>Join the <strong>Network</strong></h1>
             <p>The Gridcoin network is comprised of seven types of participants.</p>
-            <a href="#section_how_to_join" class="btn btn-outline-primary">View Details</a>
         </div>
 
         <div class="col-md-6">


### PR DESCRIPTION
Remove the obsolete `view details` button on the join page

Fixes: #11 
