### PR TITLE
fix cookie banner

### DIFF
--- a/_layouts/layout.htm
+++ b/_layouts/layout.htm
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
-    {% include _cookie_banner.htm %}
     {% include _head.htm %}
     <body>
+        {% include _cookie_banner.htm %}
         {% include _header.htm %}
         <main>{{ content }}</main>
         {% include _footer.htm %}


### PR DESCRIPTION
As @gridcat pointed out in https://github.com/gridcoin-community/Gridcoin-World-Site/issues/33, there was a problem with the cookie banner being embedded in the wrong place. 

Closes https://github.com/gridcoin-community/Gridcoin-World-Site/issues/33.