### PR TITLE
Port Gridcoin-Site#369

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,12 +6,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - name: Set up Ruby 2.6
+      - name: Set up Ruby 3.0
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: '3.0'
 
       - name: Install Bundle Dependencies 
         run: bundle install


### PR DESCRIPTION
Changes Github Actions to use checkoutv3 and Ruby 3.0